### PR TITLE
Allow direct linking to an external site from sidebar

### DIFF
--- a/javascripts/discourse/widgets/sidebar-topic-list.js.es6
+++ b/javascripts/discourse/widgets/sidebar-topic-list.js.es6
@@ -1,25 +1,23 @@
 import { createWidget } from "discourse/widgets/widget";
-import { ajax } from 'discourse/lib/ajax';
+import { ajax } from "discourse/lib/ajax";
 import { h } from "virtual-dom";
-import DiscourseUrl from 'discourse/lib/url';
+import DiscourseUrl from "discourse/lib/url";
 import { emojiUnescape } from "discourse/lib/text";
 import { censor } from "pretty-text/censored-words";
 import { isRTL } from "discourse/lib/text-direction";
 import Site from "discourse/models/site";
 import RawHtml from "discourse/widgets/raw-html";
 
+const directlyLinkable = settings.direct_links.split("|");
 
-const directlyLinkable = settings.direct_links.split('|');
-
-
-function listKey(attrs) { 
+function listKey(attrs) {
   return `${attrs.topicId}-${attrs.list.name}`;
 }
 
 function isDirectlyLinkable(url) {
-  if(url) {
+  if (url) {
     let hostname = new URL(url).hostname;
-    if(directlyLinkable.includes(hostname)) {
+    if (directlyLinkable.includes(hostname)) {
       return true;
     }
   }
@@ -30,26 +28,26 @@ function isDirectlyLinkable(url) {
 function getUrl(topic, announcement) {
   let url = topic.url;
 
-  if(announcement) {
+  if (announcement) {
     url = topic.ad_url;
-  } else if(isDirectlyLinkable(topic.featured_link)) {
+  } else if (isDirectlyLinkable(topic.featured_link)) {
     url = topic.featured_link;
   }
 
-  return url
+  return url;
 }
 
 export default createWidget("sidebar-topic-list", {
   tagName: "div.sidebar-topic-list",
   buildKey: (attrs) => `sidebar-topic-list-${listKey(attrs)}`,
-  
+
   defaultState(attrs) {
     return {
       recorded: null,
-      announcement: attrs.list.name === 'Announcements'
+      announcement: attrs.list.name === "Announcements",
     };
-  },  
-  
+  },
+
   html(attrs, state) {
     const { list } = attrs;
     const { announcement } = state;
@@ -57,63 +55,79 @@ export default createWidget("sidebar-topic-list", {
     const hasTopics = !loadingTopics && list.topics.length;
 
     let result = [];
-    
+
     if (!announcement) {
-      result.push(h('h3', h('a', { attributes: { href: `/${list.url}` }}, list.name)))
+      result.push(
+        h("h3", h("a", { attributes: { href: `/${list.url}` } }, list.name))
+      );
     }
-    
+
     let topicList;
-        
+
     if (hasTopics) {
       if (state.recorded !== listKey(attrs)) {
-        this.recordAnalytics({
-          topic_ids: attrs.list.topics.map(t => t.id)
-        }, 'topics');
+        this.recordAnalytics(
+          {
+            topic_ids: attrs.list.topics.map((t) => t.id),
+          },
+          "topics"
+        );
         state.recorded = listKey(attrs);
         this.scheduleRerender();
       }
-      
+
       topicList = this.buildTopicList(list.topics, announcement);
     } else if (loadingTopics) {
       topicList = this.buildPlaceholderList(list.max, announcement);
     } else if (!announcement) {
-      topicList = [ h(`li.no-results`, h('span', I18n.t('choose_topic.none_found'))) ];
+      topicList = [
+        h(`li.no-results`, h("span", I18n.t("choose_topic.none_found"))),
+      ];
     }
-        
-    result.push(h('ul', topicList));
-        
+
+    result.push(h("ul", topicList));
+
     return result;
   },
-  
+
   buildPlaceholderList(count, announcement) {
     return Array.apply(null, Array(parseInt(count)))
       .map(Number.prototype.valueOf, 0)
       .map(() => {
-        return h(`li.animated-placeholder.placeholder-animation.${announcement ? '.announcement' : ''}`);
+        return h(
+          `li.animated-placeholder.placeholder-animation.${
+            announcement ? ".announcement" : ""
+          }`
+        );
       });
   },
-    
+
   buildTopicList(topics, announcement) {
-    return topics.map(t => {
-      return h(`li${announcement ? '.announcement' : ''}`, this.attach("link", {
-        className: `sidebar-topic`,
-        action: "clickTopic",
-        actionParam: t,
-        href: getUrl(t, announcement),
-        contents: () => {
-          if (announcement && t.show_images && t.image_url) {
-            return h('img', { attributes: { src: t.image_url, alt: t.fancy_title }});
-          } else {
-            return new RawHtml({ html: this.buildTitleHtml(t) });
-          }
-        }
-      }))
-    })
+    return topics.map((t) => {
+      return h(
+        `li${announcement ? ".announcement" : ""}`,
+        this.attach("link", {
+          className: `sidebar-topic`,
+          action: "clickTopic",
+          actionParam: t,
+          href: getUrl(t, announcement),
+          contents: () => {
+            if (announcement && t.show_images && t.image_url) {
+              return h("img", {
+                attributes: { src: t.image_url, alt: t.fancy_title },
+              });
+            } else {
+              return new RawHtml({ html: this.buildTitleHtml(t) });
+            }
+          },
+        })
+      );
+    });
   },
-  
+
   buildTitleHtml(topic) {
     let fancyTitle = censor(
-      emojiUnescape(topic.fancy_title), 
+      emojiUnescape(topic.fancy_title),
       Site.currentProp("censored_regexp")
     );
 
@@ -121,24 +135,24 @@ export default createWidget("sidebar-topic-list", {
       const titleDir = isRTL(fancyTitle) ? "rtl" : "ltr";
       return `<span dir="${titleDir}">${fancyTitle}</span>`;
     }
-    
+
     return `<span>${fancyTitle}</span>`;
   },
-  
+
   clickTopic(topic) {
-    this.recordAnalytics({ topic_ids: [topic.id], url: topic.url }, 'click');
-    const url = getUrl(topic, this.state.announcement)
+    this.recordAnalytics({ topic_ids: [topic.id], url: topic.url }, "click");
+    const url = getUrl(topic, this.state.announcement);
     DiscourseUrl.routeTo(url);
   },
-  
+
   recordAnalytics(data, type = null) {
     let base = "/rstudio/analytics";
-    let path = `${base}/submit${type === 'click' ? '-click' : ''}`;
-    
+    let path = `${base}/submit${type === "click" ? "-click" : ""}`;
+
     ajax({
       url: `${path}.json`,
       type: "POST",
-      data
-    }).catch(e => console.log("sidebar analytics error: ", e));
-  }
+      data,
+    }).catch((e) => console.log("sidebar analytics error: ", e));
+  },
 });

--- a/javascripts/discourse/widgets/sidebar-topic-list.js.es6
+++ b/javascripts/discourse/widgets/sidebar-topic-list.js.es6
@@ -27,6 +27,18 @@ function isDirectlyLinkable(url) {
   return false;
 }
 
+function getUrl(topic, announcement) {
+  let url = topic.url;
+
+  if(announcement) {
+    url = topic.ad_url;
+  } else if(isDirectlyLinkable(topic.featured_link)) {
+    url = topic.featured_link;
+  }
+
+  return url
+}
+
 export default createWidget("sidebar-topic-list", {
   tagName: "div.sidebar-topic-list",
   buildKey: (attrs) => `sidebar-topic-list-${listKey(attrs)}`,
@@ -87,6 +99,7 @@ export default createWidget("sidebar-topic-list", {
         className: `sidebar-topic`,
         action: "clickTopic",
         actionParam: t,
+        href: getUrl(t, announcement),
         contents: () => {
           if (announcement && t.show_images && t.image_url) {
             return h('img', { attributes: { src: t.image_url, alt: t.fancy_title }});
@@ -114,16 +127,7 @@ export default createWidget("sidebar-topic-list", {
   
   clickTopic(topic) {
     this.recordAnalytics({ topic_ids: [topic.id], url: topic.url }, 'click');
-    
-    let url = topic.url;
-
-    if(this.state.announcement) {
-      url = topic.ad_url;
-    }
-    else if(isDirectlyLinkable(topic.featured_link)) {
-      url = topic.featured_link;
-    }
-
+    const url = getUrl(topic, this.state.announcement)
     DiscourseUrl.routeTo(url);
   },
   

--- a/javascripts/discourse/widgets/sidebar-topic-list.js.es6
+++ b/javascripts/discourse/widgets/sidebar-topic-list.js.es6
@@ -8,8 +8,23 @@ import { isRTL } from "discourse/lib/text-direction";
 import Site from "discourse/models/site";
 import RawHtml from "discourse/widgets/raw-html";
 
+
+const directlyLinkable = settings.direct_links.split('|');
+
+
 function listKey(attrs) { 
   return `${attrs.topicId}-${attrs.list.name}`;
+}
+
+function isDirectlyLinkable(url) {
+  if(url) {
+    let hostname = new URL(url).hostname;
+    if(directlyLinkable.includes(hostname)) {
+      return true;
+    }
+  }
+
+  return false;
 }
 
 export default createWidget("sidebar-topic-list", {
@@ -28,7 +43,7 @@ export default createWidget("sidebar-topic-list", {
     const { announcement } = state;
     const loadingTopics = list.topics === null;
     const hasTopics = !loadingTopics && list.topics.length;
-    
+
     let result = [];
     
     if (!announcement) {
@@ -99,7 +114,16 @@ export default createWidget("sidebar-topic-list", {
   
   clickTopic(topic) {
     this.recordAnalytics({ topic_ids: [topic.id], url: topic.url }, 'click');
-    const url = this.state.announcement ? topic.ad_url : topic.url;
+    
+    let url = topic.url;
+
+    if(this.state.announcement) {
+      url = topic.ad_url;
+    }
+    else if(isDirectlyLinkable(topic.featured_link)) {
+      url = topic.featured_link;
+    }
+
     DiscourseUrl.routeTo(url);
   },
   

--- a/settings.yaml
+++ b/settings.yaml
@@ -3,4 +3,4 @@ topic_lists:
   type: list
   default: ""
   description:
-    en: "Comma seperated title, query and max for each topic list."
+    en: "Comma separated title, query and max for each topic list."

--- a/settings.yaml
+++ b/settings.yaml
@@ -4,3 +4,8 @@ topic_lists:
   default: ""
   description:
     en: "Comma separated title, query and max for each topic list."
+direct_links:
+  type: list
+  default: ""
+  description:
+    en: "Sites to directly link to from the sidebar instead of linking to the topic."


### PR DESCRIPTION
Sites to use external links for are configurable in settings. Also includes a fix for the href of topics in the sidebar not showing correctly, and reformats the file with Prettier defaults.